### PR TITLE
Nelisjunior patch 1

### DIFF
--- a/windows/noAdmin/Backup-extensions.ps1
+++ b/windows/noAdmin/Backup-extensions.ps1
@@ -1,0 +1,49 @@
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+# Configuracoes - AGORA USANDO DIRETÓRIO ATUAL
+$edgeExtensionsPath = "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Extensions"
+$backupFolderName = "BackupEdgeExtensions"
+$backupFolder = Join-Path -Path (Get-Location) -ChildPath $backupFolderName  # <-- Mudanca crucial aqui
+$extensionIDs = @(
+    "dppgmdbiimibapkepcbdbmkaabgiofem",
+    "odfafepnkmbhccpbejgmiehpchacaeak",
+    "hfjadhjooeceemgojogkhlppanjkbobc"
+)
+
+# Verifica se o Edge está instalado
+if (-not (Test-Path -Path $edgeExtensionsPath)) {
+    Write-Host "Pasta de extensoes do Edge nao encontrada!" -ForegroundColor Red
+    exit
+}
+
+# Cria pasta de backup no diretório atual
+if (-not (Test-Path -Path $backupFolder)) {
+    New-Item -ItemType Directory -Path $backupFolder -Force | Out-Null
+}
+
+# Processa cada extensao
+foreach ($id in $extensionIDs) {
+    $sourcePath = Join-Path -Path $edgeExtensionsPath -ChildPath $id
+    $destPath = Join-Path -Path $backupFolder -ChildPath $id
+    $zipPath = Join-Path -Path $backupFolder -ChildPath "$id.zip"
+
+    if (Test-Path -Path $sourcePath) {
+        try {
+            # Copia, compacta e remove a cópia
+            Copy-Item -Path $sourcePath -Destination $destPath -Recurse -Force
+            Compress-Archive -Path $destPath -DestinationPath $zipPath -Force
+            Remove-Item -Path $destPath -Recurse -Force
+            Write-Host "$id -> $(Split-Path $zipPath -Leaf)" -ForegroundColor Green
+        }
+        catch {
+            Write-Host "Falha ao processar $id : $_" -ForegroundColor Red
+        }
+    }
+    else {
+        Write-Host "Extensao $id nao encontrada" -ForegroundColor Yellow
+    }
+}
+
+Write-Host "`nBackup concluido! Pasta: $backupFolder" -ForegroundColor Cyan
+explorer $backupFolder

--- a/windows/noAdmin/Install-EdgeExtensions.ps1
+++ b/windows/noAdmin/Install-EdgeExtensions.ps1
@@ -1,0 +1,38 @@
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+# Configuracões - BUSCA NA PASTA DO SCRIPT
+$backupFolder = Join-Path -Path (Get-Location) -ChildPath "BackupEdgeExtensions"  # <-- Diretório atual
+$edgeExtensionsPath = "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Extensions"
+
+# Fecha o Edge se estiver aberto
+Stop-Process -Name "msedge" -ErrorAction SilentlyContinue
+
+# Verifica se a pasta de backup existe
+if (-not (Test-Path -Path $backupFolder)) {
+    Write-Host "Pasta de backup nao encontrada!" -ForegroundColor Red
+    Write-Host "Execute primeiro o script de backup." -ForegroundColor Yellow
+    exit
+}
+
+# Processa cada arquivo ZIP
+Get-ChildItem -Path $backupFolder -Filter *.zip | ForEach-Object {
+    $id = $_.BaseName
+    $extractPath = Join-Path -Path $edgeExtensionsPath -ChildPath $id
+
+    try {
+        # Remove versao existente
+        if (Test-Path -Path $extractPath) {
+            Remove-Item -Path $extractPath -Recurse -Force
+        }
+
+        # Extrai o ZIP
+        Expand-Archive -Path $_.FullName -DestinationPath $edgeExtensionsPath -Force
+        Write-Host "Extensao $id instalada" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "Falha ao instalar $id : $_" -ForegroundColor Red
+    }
+}
+
+Write-Host "`nInstalacao concluida! Reinicie o Edge." -ForegroundColor Cyan

--- a/windows/noAdmin/README.md
+++ b/windows/noAdmin/README.md
@@ -1,0 +1,2 @@
+# Scripts que não requerem permissões de ADMIN
+

--- a/windows/noAdmin/README.md
+++ b/windows/noAdmin/README.md
@@ -1,2 +1,11 @@
 # Scripts que não requerem permissões de ADMIN
 
+Esta pasta contém scripts desenvolvidos para uso sem permissões administrativas no Windows. O objetivo principal é fornecer métodos alternativos para:
+
+- Realizar cópias de segurança das extensões do navegador Edge
+- Instalar extensões do Edge sem a necessidade de privilégios elevados
+
+Esses scripts são especialmente úteis em ambientes corporativos, onde políticas de segurança frequentemente impedem até mesmo a instalação de extensões no navegador. Isso pode comprometer significativamente a experiência do usuário e, consequentemente, a produtividade.
+
+> **Nota pessoal:** Quem cria restrições desse tipo provavelmente não teve muito amor a vida.
+

--- a/windows/noAdmin/run.bat
+++ b/windows/noAdmin/run.bat
@@ -1,0 +1,61 @@
+@echo off
+reg add "HKCU\Console" /v CodePage /t REG_DWORD /d 65001 /f
+chcp 65001 > nul
+
+:: Configuraçao de cores (removida para evitar conflitos com UTF-8)
+:: Menu principal
+:menu
+cls
+echo  [Menu Principal]
+echo.
+echo   1. Fazer backup de extensoes especificas do Edge
+echo   2. Instalar extensoes a partir de arquivos ZIP
+echo   3. Sair
+echo.
+set /p choice="Escolha uma opçao (1-3): "
+
+if "%choice%"=="1" goto backup
+if "%choice%"=="2" goto install
+if "%choice%"=="3" exit /b
+
+echo Opçao invalida! Pressione qualquer tecla para tentar novamente...
+pause >nul
+goto menu
+
+:backup
+cls
+echo  [BACKUP DE EXTENSOES]
+echo.
+echo Verificando scripts disponiveis...
+
+set "backup_script=%~dp0Backup-extensions.ps1"
+if not exist "%backup_script%" (
+    echo Erro: Script Backup-extensions.ps1 nao encontrado!
+    pause
+    goto menu
+)
+
+echo Executando backup das extensoes...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%backup_script%"
+echo.
+pause
+goto menu
+
+:install
+cls
+echo  [INSTALAÇaO DE EXTENSoES]
+echo.
+echo Verificando scripts disponiveis...
+
+set "install_script=%~dp0Install-EdgeExtensions.ps1"
+if not exist "%install_script%" (
+    echo Erro: Script Install-EdgeExtensions.ps1 nao encontrado!
+    pause
+    goto menu
+)
+
+echo Executando instalaçao de extensoes...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%install_script%"
+echo.
+pause
+goto menu


### PR DESCRIPTION
This pull request introduces a set of scripts and utilities designed for managing Edge browser extensions without requiring administrative privileges. The changes include new PowerShell scripts for backing up and installing extensions, a batch file for running these scripts via a menu interface, and documentation updates. These tools are tailored for restrictive environments, such as corporate systems, where administrative access is limited.

### New functionality for managing Edge extensions:

- **Backup Edge extensions:**
  - Added `Backup-extensions.ps1` script to back up specific Edge extensions to a ZIP format in the current directory. It verifies the existence of the Edge extensions folder, creates a backup folder if needed, and compresses the extensions.
  
- **Install Edge extensions:**
  - Added `Install-EdgeExtensions.ps1` script to restore Edge extensions from backup ZIP files. It stops the Edge process, removes existing extension versions, and extracts the ZIP files into the appropriate directory.

### User interface enhancements:

- **Menu-driven batch file:**
  - Added `run.bat` to provide a simple menu interface for running the backup and installation scripts. The batch file ensures proper UTF-8 encoding and checks for the availability of required scripts before execution.

### Documentation improvements:

- **README for non-admin scripts:**
  - Added `README.md` to explain the purpose and usage of the scripts, emphasizing their utility in restrictive environments without administrative permissions. Includes a lighthearted note about restrictive policies.